### PR TITLE
Correct syntax presented to user when connecting to wifi

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -105,7 +105,7 @@ static const MenuCommand wifi_commands[] = {
     GHOST_ESP_APP_FOLDER_PCAPS, false, NULL, false, NULL, NULL},
 
    // Interactive Operations
-   {"Connect WiFi", "connect", NULL, NULL, NULL, true, "SSID,Password", 
+   {"Connect WiFi", "connect", NULL, NULL, NULL, true, "SSID Password", 
     false, NULL, NULL},
 
    // Dangerous Operations

--- a/src/menu.c
+++ b/src/menu.c
@@ -324,15 +324,15 @@ static const MenuCommand wifi_commands[] = {
         .file_ext = NULL,
         .folder = NULL,
         .needs_input = true,
-        .input_text = "SSID,Password",
+        .input_text = "SSID Password",
         .needs_confirmation = false,
         .confirm_header = NULL,
         .confirm_text = NULL,
         .details_header = "WiFi Connect",
         .details_text = "Connect ESP to WiFi:\n"
                         "Enter SSID & password\n"
-                        "separated by comma.\n"
-                        "Example: network,pass\n",
+                        "separated by a space.\n"
+                        "Example: network pass\n",
     },
     {
         .label = "Cast Random Video",


### PR DESCRIPTION
The connect command as configured currently expects input in the form SSID<space>Password according to the [ghost_esp documentation](https://github.com/jaylikesbunda/Ghost_ESP/wiki/Commands#-network-connection--tools). 

When submitting an SSID and Password separated by a comma the user would experience an error. This corrects the issue by updating the documentation presented to the user when entering such details. 

Admittedly this will likely cause issues when connecting to an SSID with spaces in the name.